### PR TITLE
Allow users to not define KEY MANAGER envs

### DIFF
--- a/templates/api/configmap-env.yaml
+++ b/templates/api/configmap-env.yaml
@@ -15,6 +15,8 @@ data:
 {{- range $key,$value := .Values.api.environment }}
   {{ $key }}: {{ $value | quote }}
 {{- end }}
+{{- if .Values.keyManager.enabled }}
   KEY_MANAGER_URL: {{ .Values.api.environment.KEY_MANAGER_URL | default (include "orchestrate.keyManager.defaultHTTPURL" .) | quote }}
   KEY_MANAGER_METRICS_URL: {{ .Values.api.environment.KEY_MANAGER_METRICS_URL | default (include "orchestrate.keyManager.defaultMetricsURL" .) | quote }}
+{{- end }}
 {{- end }}

--- a/templates/test/configmap-env.yaml
+++ b/templates/test/configmap-env.yaml
@@ -16,8 +16,10 @@ data:
 {{- end }}
   API_URL: {{ .Values.test.environment.API_URL | default (include "orchestrate.api.defaultHTTPURL" .) | quote }}
   API_METRICS_URL: {{ .Values.test.environment.API_METRICS_URL | default (include "orchestrate.api.defaultMetricsURL" .) | quote }}
+{{- if .Values.keyManager.enabled }}
   KEY_MANAGER_URL: {{ .Values.test.environment.KEY_MANAGER_URL | default (include "orchestrate.keyManager.defaultHTTPURL" .) | quote }}
   KEY_MANAGER_METRICS_URL: {{ .Values.test.environment.KEY_MANAGER_METRICS_URL | default (include "orchestrate.keyManager.defaultMetricsURL" .) | quote }}
+{{- end }}
   TX_LISTENER_METRICS_URL: {{ .Values.test.environment.TX_LISTENER_METRICS_URL | default (include "orchestrate.txListener.defaultMetricsURL" .) | quote }}
   TX_SENDER_METRICS_URL: {{ .Values.test.environment.TX_SENDER_METRICS_URL | default (include "orchestrate.txSender.defaultMetricsURL" .) | quote }}
 {{- end }}

--- a/templates/tx-sender/configmap-env.yaml
+++ b/templates/tx-sender/configmap-env.yaml
@@ -17,6 +17,8 @@ data:
 {{- end }}
   API_URL: {{ .Values.txSender.environment.API_URL | default (include "orchestrate.api.defaultHTTPURL" .) | quote }}
   API_METRICS_URL: {{ .Values.txSender.environment.API_METRICS_URL | default (include "orchestrate.api.defaultMetricsURL" .) | quote }}
+{{- if .Values.keyManager.enabled }}
   KEY_MANAGER_URL: {{ .Values.txSender.environment.KEY_MANAGER_URL | default (include "orchestrate.keyManager.defaultHTTPURL" .) | quote }}
   KEY_MANAGER_METRICS_URL: {{ .Values.txSender.environment.KEY_MANAGER_METRICS_URL | default (include "orchestrate.keyManager.defaultMetricsURL" .) | quote }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines -->

## PR Description

## Fixed Issue(s)

<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `documentation` label to this PR if updates are required.
