### PR TITLE
Feat/vault agent key manager fix

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,9 +3,9 @@ apiVersion: v2
 description: Helm chart for Orchestrate
 name: orchestrate
 type: application
-version: 1.0.5
+version: 1.0.7
 home: https://docs.orchestrate.consensys.net/
 icon: https://docs.orchestrate.consensys.net/en/stable/images/logo.svg
 maintainers:
   - name: christian.tran
-appVersion: 21.1.5
+appVersion: 21.1.12

--- a/templates/key-manager/deployment.yaml
+++ b/templates/key-manager/deployment.yaml
@@ -50,7 +50,6 @@ spec:
                 agent_pid=$!
               }
               function stop_agent() {
-                rm -f /vault/token/reboot
                 kill -15 ${agent_pid}
               }
               # Main

--- a/templates/key-manager/deployment.yaml
+++ b/templates/key-manager/deployment.yaml
@@ -38,10 +38,27 @@ spec:
               add:
               - IPC_LOCK
           image: "{{ .Values.keyManager.vaultAgent.image.repository }}:{{ .Values.keyManager.vaultAgent.image.tag }}"
+          command: [ "/bin/sh" ]
           args:
-            - "agent"
-            - "-config"
-            - "/vault/config/agent-config.hcl"
+            - "-c"
+            - |
+              set -e
+              cfg=/vault/config/agent-config.hcl
+              agent_pid=
+              function start_agent() {
+                /usr/local/bin/docker-entrypoint.sh agent -config ${cfg} &
+                agent_pid=$!
+              }
+              function stop_agent() {
+                rm -f /vault/token/reboot
+                kill -15 ${agent_pid}
+              }
+              # Main
+              while :; do
+               start_agent
+               echo -e "HTTP/1.1 200 OK\n\n $(date)" | nc -l -p 9999
+               stop_agent
+              done
           env:
             - name: SKIP_CHOWN
               value: "true"
@@ -94,6 +111,11 @@ spec:
             - name: http-metrics
               containerPort: 8082
               protocol: TCP
+          lifecycle:
+            postStart:
+              httpGet:
+                port: 9999
+                path: /
           livenessProbe:
             httpGet:
               path: /live

--- a/values.yaml
+++ b/values.yaml
@@ -18,8 +18,8 @@ global:
     password: sillyness
 
   image:
-    repository: docker.consensys.net/priv/orchestrate
-    tag: v21.1.5
+    repository: consensys/orchestrate
+    tag: v21.1.12
     pullPolicy: IfNotPresent
 
   ## String to partially override prometheus.fullname template (will maintain the release name)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines -->

## PR Description
With these changes everytime the container key-manager is started it will trigger a restart of the vault-agent sidecar.
## Fixed Issue(s)
When key-manager container restarts (for wathever reason) it fails to read the vault token (it was deleted during its first run).

<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.
